### PR TITLE
Remove redundant dependence

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -13,6 +13,6 @@ export function useAutoAnimate<T extends Element>(
   useEffect(() => {
     if (element.current instanceof HTMLElement)
       autoAnimate(element.current, options)
-  }, [element])
+  }, [])
   return [element]
 }


### PR DESCRIPTION
`useRef` never 'changes' meaning there is not need to use it as a `useEffect` dependency. 

> Keep in mind that useRef doesn’t notify you when its content changes. Mutating the .current property doesn’t cause a re-render. If you want to run some code when React attaches or detaches a ref to a DOM node, you may want to use a callback ref instead.

https://reactjs.org/docs/hooks-reference.html#useref