### PR TITLE
support version 17 and 18 of react

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16.8.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "vue": "^3.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Hi.

I'm pretty sure both react and vue should be removed as peerDependencies, specially given this package can be used in any javascript application.

That being said, we have builds failing in CI and I don't think it's correct to just `--legacy-peer-deps` because of it.
This PR adds react 17 and 18 as acceptable versions in peer deps.

Feel free to close if you chose to remove them instead.

Closes #4 