### PR TITLE
adds useAutoAnimate vue composable

### DIFF
--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,8 +1,30 @@
-import type { Plugin } from "vue"
-import { vAutoAnimate } from "../index"
+import { ref, onMounted, Plugin, Ref } from "vue"
+import autoAnimate, { vAutoAnimate, AutoAnimateOptions, AutoAnimationPlugin } from "../index"
 
 export const autoAnimatePlugin: Plugin = {
   install(app) {
     app.directive("auto-animate", vAutoAnimate)
   },
+}
+
+/**
+ * AutoAnimate hook for adding dead-simple transitions and animations to Vue.
+ * @param options - Auto animate options or a plugin
+ * @returns A function ref, which you should bind to the `ref` attribute
+ * of your target element so `autoAnimate` can access it.
+ */
+ export function useAutoAnimate<T extends Element>(
+  options: Partial<AutoAnimateOptions> | AutoAnimationPlugin = {}
+) {
+  const element = ref<T>()
+  const functionRef: (el: T) => void = el => {
+    if (el) element.value = el
+  }
+
+  onMounted(() => {
+    if (element.value instanceof HTMLElement)
+      autoAnimate(element.value, options)
+  })
+
+  return functionRef
 }


### PR DESCRIPTION
`useAutoAnimate` is a Vue composable that:
- Enhances TypeScript experience (`v-auto-animate` doesn't type-check or autocomplete custom options, but `useAutoAnimate` does)
- Closely matches the React `useAutoAnimate` API and usage
- Doesn't have the (admittedly very small) naming collision risk of `v-auto-animate`

Example usage can be seen here: https://stackblitz.com/edit/vue-useautoanimate?file=src%2FActualVueApp.vue