### PR TITLE
simplifies vue useAutoAnimate composable and adds docs

### DIFF
--- a/docs/src/components/Navigation.vue
+++ b/docs/src/components/Navigation.vue
@@ -41,7 +41,8 @@ if (typeof window !== "undefined") {
       <li><a href="#installation">Installation</a></li>
       <li><a href="#usage">Usage</a></li>
       <li><a href="#usage-react">React hook</a></li>
-      <li><a href="#usage-vue">Vue directive</a></li>
+      <li><a href="#usage-vue-directive">Vue directive</a></li>
+      <li><a href="#usage-vue-composable">Vue composable</a></li>
       <li><a href="#usage-svelte">Svelte action</a></li>
       <li><a href="#usage-angular">Angular directive</a></li>
       <li><a href="#examples">Examples</a></li>

--- a/docs/src/examples/vue/AnotherActualVueApp.vue
+++ b/docs/src/examples/vue/AnotherActualVueApp.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { ref } from 'vue'
+import { useAutoAnimate } from "../../../../src/vue"
+
+const items = ref(["React", "Vue", "Svelte", "Angular"])
+
+function sortAsc() {
+  items.value.sort()
+}
+function sortDesc() {
+  items.value.sort().reverse()
+}
+
+const parent = useAutoAnimate()
+</script>
+
+<template>
+  <div>
+    <button class="button" @click="sortAsc">Sort A-Z ↑</button>
+    <button class="button" @click="sortDesc">Sort Z-A ↓</button>
+  </div>
+  <ul ref="parent">
+    <li
+      v-for="item in items"
+      :key="item"
+    >
+      {{ item }}
+    </li>
+  </ul>
+</template>

--- a/docs/src/examples/vue/index.ts
+++ b/docs/src/examples/vue/index.ts
@@ -37,4 +37,42 @@ function removeItem(toRemove) {
 </template>`,
   },
 }
-export { vueDirectiveMain, vueDirectiveApp }
+
+const vueComposable = {
+  vue: {
+    ext: "vue",
+    language: "html",
+    example: `<script setup>
+import { ref } from 'vue'
+import { useAutoAnimate } from '@formkit/auto-animate/vue'
+
+const items = ref(["React", "Vue", "Svelte", "Angular"])
+
+function sortAsc() {
+  items.value.sort()
+}
+function sortDesc() {
+  items.value.sort().reverse()
+}
+
+const parent = useAutoAnimate()
+</script>
+
+<template>
+  <div>
+    <button @click="sortAsc">Sort A-Z ↑</button>
+    <button @click="sortDesc">Sort Z-A ↓</button>
+  </div>
+  <ul ref="parent">
+    <li
+      v-for="item in items"
+      :key="item"
+    >
+      {{ item }}
+    </li>
+  </ul>
+</template>`,
+  }
+}
+
+export { vueDirectiveMain, vueDirectiveApp, vueComposable }

--- a/docs/src/sections/SectionInstallation.vue
+++ b/docs/src/sections/SectionInstallation.vue
@@ -31,7 +31,7 @@ import AsideTip from "../components/AsideTip.vue"
     <p>Aaaaand, you’re done! That was fast. 🐇</p>
     <AsideTip>
       If you are using React, you can use the <code><a href="#usage-react">useAutoAnimate</a></code> hook.
-      If you are using Vue, you can use the <code><a href="#usage-vue">v-auto-animate</a></code> directive.
+      If you are using Vue, you can use the <code><a href="#usage-vue-directive">v-auto-animate</a></code> directive or the <code><a href="#usage-vue-composable">useAutoAnimate</a></code> composable.
     </AsideTip>
   </section>
 </template>

--- a/docs/src/sections/SectionUsage.vue
+++ b/docs/src/sections/SectionUsage.vue
@@ -3,7 +3,7 @@ import CodeExample from "../components/CodeExample.vue"
 import AsideTip from "../components/AsideTip.vue"
 import dropdown from "../examples/dropdown"
 import config from "../examples/config"
-import { vueDirectiveMain, vueDirectiveApp } from "../examples/vue"
+import { vueDirectiveMain, vueDirectiveApp, vueComposable } from "../examples/vue"
 import { angularDirectiveMain, angularDirectiveApp } from "../examples/angular"
 import reactHook from "../examples/react"
 import ActualReactApp from "../examples/react/ActualReactApp.vue"
@@ -11,6 +11,7 @@ import ActualDropdown from "../examples/dropdown/ActualDropdown.vue"
 import svelteAction from "../examples/svelte"
 import ActualSvelteApp from "../examples/svelte/ActualSvelteApp.vue"
 import ActualVueApp from "../examples/vue/ActualVueApp.vue"
+import AnotherActualVueApp from "../examples/vue/AnotherActualVueApp.vue"
 import ActualAngularApp from "../examples/angular/ActualAngularApp.vue"
 </script>
 <template>
@@ -98,7 +99,7 @@ import ActualAngularApp from "../examples/angular/ActualAngularApp.vue"
     <CodeExample :examples="reactHook" title="App" />
     <ActualReactApp />
 
-    <h2 id="usage-vue">Vue directive</h2>
+    <h2 id="usage-vue-directive">Vue directive</h2>
     <p>
       Vue users can globally register the
       <code>v-auto-animate</code> directive. This makes adding transitions and
@@ -118,6 +119,26 @@ import ActualAngularApp from "../examples/angular/ActualAngularApp.vue"
       <code>&lt;ul v-auto-animate="{ duration: 100 }"&gt;</code>
     </AsideTip>
 
+    <h2 id="usage-vue-composable">Vue composable</h2>
+    <p>
+      As an alternative to the <code>v-auto-animate</code> directive, Vue devs
+      can use the <code>useAutoAnimate</code> composable. This composable
+      supports all the same great features, but also enhances the TypeScript experience
+      by type-checking and autocompleting any custom options you might pass.
+    </p>
+    <p>
+      Import the composable from <code>@formkit/auto-animate/vue</code>, and call it in
+      <code>script setup</code> to create a 
+      <a href="https://vuejs.org/guide/essentials/template-refs.html#template-refs" target="_blank" rel="noopener noreferrer">template ref</a>.
+      Use the <code>ref</code> attribute on your parent element to store it in the template ref:
+    </p>
+    <CodeExample :examples="vueComposable" title="App" />
+    <AnotherActualVueApp />
+    <AsideTip>
+      Vue users can pass options directly to the composable: <br />
+      <code>useAutoAnimate({ duration: 100 })</code>
+    </AsideTip>
+
     <h2 id="usage-svelte">Svelte action</h2>
     <p>
       The root <code>autoAnimate</code> function can be directly used as a
@@ -127,7 +148,7 @@ import ActualAngularApp from "../examples/angular/ActualAngularApp.vue"
     <CodeExample :examples="svelteAction" title="App" />
     <ActualSvelteApp />
     <AsideTip>
-      Svelte users can pass options by directly setting the directive’s value
+      Svelte users can pass options by directly setting the action’s value
       <code
         >&lt;ul use:autoAnimate=&#123;&#123; duration: 1000
         &#125;&#125;&gt;</code

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, Plugin, Ref } from "vue"
+import { ref, onMounted, watchEffect, Plugin, Ref } from "vue"
 import autoAnimate, { vAutoAnimate, AutoAnimateOptions, AutoAnimationPlugin } from "../index"
 
 export const autoAnimatePlugin: Plugin = {
@@ -10,21 +10,20 @@ export const autoAnimatePlugin: Plugin = {
 /**
  * AutoAnimate hook for adding dead-simple transitions and animations to Vue.
  * @param options - Auto animate options or a plugin
- * @returns A function ref, which you should bind to the `ref` attribute
- * of your target element so `autoAnimate` can access it.
+ * @returns A template ref. Use the `ref` attribute of your parent element
+ * to store the element in this template ref.
  */
  export function useAutoAnimate<T extends Element>(
   options: Partial<AutoAnimateOptions> | AutoAnimationPlugin = {}
-) {
+): Ref<T> {
   const element = ref<T>()
-  const functionRef: (el: T) => void = el => {
-    if (el) element.value = el
-  }
 
   onMounted(() => {
-    if (element.value instanceof HTMLElement)
-      autoAnimate(element.value, options)
+    watchEffect(() => {
+      if (element.value instanceof HTMLElement)
+        autoAnimate(element.value, options)
+    })
   })
 
-  return functionRef
+  return element as Ref<T>
 }


### PR DESCRIPTION
Per [some guidance I wrote recently](https://gist.github.com/AlexVipond/94892f017e122f10b33887839a1a96b3), I changed `useAutoAnimate` to return a normal template ref instead of a function ref. The function ref is not necessary in this use case, and is more likely to confuse other devs compared to the more familiar template ref approach.