### PR TITLE
init react autoanimate using callback ref instead of useEffect

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -19,6 +19,8 @@ export function useAutoAnimate<T extends Element>(
   const element = useCallback((node: T) => {
     if (node instanceof HTMLElement) {
       setController(autoAnimate(node, options))
+    } else {
+      setController(undefined);
     }
   }, [])
   const setEnabled = (enabled: boolean) => {

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, RefObject } from "react"
+import { useState, useCallback, RefCallback } from "react"
 import autoAnimate, {
   AutoAnimateOptions,
   AutoAnimationPlugin,
@@ -12,19 +12,19 @@ import autoAnimate, {
  */
 export function useAutoAnimate<T extends Element>(
   options: Partial<AutoAnimateOptions> | AutoAnimationPlugin = {}
-): [RefObject<T>, (enabled: boolean) => void] {
-  const element = useRef<T>(null)
+): [RefCallback<T>, (enabled: boolean) => void] {
   const [controller, setController] = useState<
     AnimationController | undefined
   >()
+  const element = useCallback((node: T) => {
+    if (node instanceof HTMLElement) {
+      setController(autoAnimate(node, options))
+    }
+  }, [])
   const setEnabled = (enabled: boolean) => {
     if (controller) {
       enabled ? controller.enable() : controller.disable()
     }
   }
-  useEffect(() => {
-    if (element.current instanceof HTMLElement)
-      setController(autoAnimate(element.current, options))
-  }, [])
   return [element, setEnabled]
 }


### PR DESCRIPTION
## The problem

The current implementation of react useAutoAnimate hook uses useEffect to trigger autoanimate(element), while this approach works when the element is already rendered, it doesn't work when element is not yet mounted.

here is a [codesanbox](https://codesandbox.io/s/autoanimate-issue-lfcvd0?file=/src/App.js) that shows the problem ( you can notice animation does not work).
here is an example where useAutoAnimate does not work: 

```jsx
function Component() {
  const [visible, setVisible] = useState(false)
  const [ref] = useAutoAnimate()
  return (
    <div>
    	{visible && <div ref={ref}></div>}
    </div>
  )
}
```

## The solution
Using callback ref, it doesnt' matter if the element is rendered or not, since React calls ref callback when the element if rendered on the first time, this implies to use useCallback for the callback ref to guarantee it will run only on the first render of the element, because React uses referential stability to check if the callback ref should be run or not.

here is a [codesanbox](https://codesandbox.io/s/autoanimate-with-callback-ref-r31x6d?file=/src/App.js:0-820) that solves the problem with callback ref. 
