### PR TITLE
Update Vue's docs

### DIFF
--- a/docs/src/sections/SectionUsage.vue
+++ b/docs/src/sections/SectionUsage.vue
@@ -146,12 +146,11 @@ import IconSvelte from "../components/IconSvelte.vue"
     <CodeExample :examples="vueDirectiveApp" title="App" />
     <ActualVueApp />
     <AsideTip>
+      Please bare in mind that value passed to <code>:key</code> should be a unique value, otherwise animation might not work as expected.
+    </AsideTip>
+    <AsideTip>
       Vue users can pass options by directly setting the directive’s value
       <code>&lt;ul v-auto-animate="{ duration: 100 }"&gt;</code>
-    </AsideTip>
-    
-    <AsideTip>
-      Please bare in mind that value passed to <code>:key</code> should be an unique value, otherwise animation might not work as expected.
     </AsideTip>
 
     <h3 id="usage-vue-composable">Vue composable</h3>

--- a/docs/src/sections/SectionUsage.vue
+++ b/docs/src/sections/SectionUsage.vue
@@ -149,6 +149,10 @@ import IconSvelte from "../components/IconSvelte.vue"
       Vue users can pass options by directly setting the directive’s value
       <code>&lt;ul v-auto-animate="{ duration: 100 }"&gt;</code>
     </AsideTip>
+    
+    <AsideTip>
+      Please bare in mind that value passed to <code>:key</code> should be an unique value, otherwise animation might not work as expected.
+    </AsideTip>
 
     <h3 id="usage-vue-composable">Vue composable</h3>
     <p>


### PR DESCRIPTION
Adds info to docs about a necessity of using a unique `:key` when using the library with Vue.js.