### PR TITLE
Support animations inside shadow dom

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,7 +299,7 @@ function target(el: Element, child?: Element) {
  * @param el - The specific element to animate.
  */
 function animate(el: Element) {
-  const isMounted = root.contains(el)
+  const isMounted = el.isConnected
   const preExisting = coords.has(el)
   if (isMounted && siblings.has(el)) siblings.delete(el)
   if (animations.has(el)) {


### PR DESCRIPTION
auto animate currently fails when the elements to animate are located inside a shadow root as `document.contains(el)` is `false` when the `el` is inside a shadow root. `el.isConnected` allows to detected whether an element is mounted on top level as well as inside shadow roots.