### PR TITLE
improve easing type for autocomplete

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -632,7 +632,7 @@ export interface AutoAnimateOptions {
    * The type of easing to use.
    * Default: ease-in-out
    */
-  easing: "linear" | "ease-in" | "ease-out" | "ease-in-out" | string
+  easing: "linear" | "ease-in" | "ease-out" | "ease-in-out" | ({} & string)
   /**
    * Ignore a user’s "reduce motion" setting and enable animations. It is not
    * recommended to use this.


### PR DESCRIPTION
currently the type for easing `"linear" | "ease-in" | "ease-out" | "ease-in-out" | string` doesn't let typescript suggest the possible values. By using `({} & string)` typescript shows the values while also alllowing any string as indended originally

before
![image](https://github.com/formkit/auto-animate/assets/48163890/f46d06ae-b38c-4103-96b2-2bd4555c7058)

after
![image](https://github.com/formkit/auto-animate/assets/48163890/54b15250-12cb-4e71-b86d-a45975009740)

