### PR TITLE
Style reset configurable by plugin authors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -156,8 +156,7 @@ function observePosition(el: Element) {
 function updatePos(el: Element) {
   clearTimeout(debounces.get(el))
   const optionsOrPlugin = getOptions(el)
-  const delay =
-    typeof optionsOrPlugin === "function" ? 500 : optionsOrPlugin.duration
+  const delay = isPlugin(optionsOrPlugin) ? 500 : optionsOrPlugin.duration
   debounces.set(
     el,
     setTimeout(async () => {
@@ -458,6 +457,26 @@ function forEach(
 }
 
 /**
+ * Always return tuple to provide consistent interface
+ */
+function getPluginTuple(
+  pluginReturn: ReturnType<AutoAnimationPlugin>
+): [KeyframeEffect, AutoAnimationPluginOptions] | [KeyframeEffect] {
+  if (Array.isArray(pluginReturn)) return pluginReturn
+
+  return [pluginReturn]
+}
+
+/**
+ * Determine if config is plugin
+ */
+function isPlugin(
+  config: Partial<AutoAnimateOptions> | AutoAnimationPlugin
+): config is AutoAnimationPlugin {
+  return typeof config === "function"
+}
+
+/**
  * The element in question is remaining in the DOM.
  * @param el - Element to flip
  * @returns
@@ -496,9 +515,10 @@ function remain(el: Element) {
       easing: pluginOrOptions.easing,
     })
   } else {
-    animation = new Animation(
+    const [keyframes] = getPluginTuple(
       pluginOrOptions(el, "remain", oldCoords, newCoords)
     )
+    animation = new Animation(keyframes)
     animation.play()
   }
   animations.set(el, animation)
@@ -529,7 +549,8 @@ function add(el: Element) {
       }
     )
   } else {
-    animation = new Animation(pluginOrOptions(el, "add", newCoords))
+    const [keyframes] = getPluginTuple(pluginOrOptions(el, "add", newCoords))
+    animation = new Animation(keyframes)
     animation.play()
   }
   animations.set(el, animation)
@@ -564,7 +585,7 @@ function remove(el: Element) {
   const optionsOrPlugin = getOptions(el)
   const oldCoords = coords.get(el)!
   let animation: Animation
-  Object.assign((el as HTMLElement).style, {
+  const defaultStyleReset = {
     position: "absolute",
     top: `${top}px`,
     left: `${left}px`,
@@ -574,8 +595,9 @@ function remove(el: Element) {
     pointerEvents: "none",
     transformOrigin: "center",
     zIndex: 100,
-  })
-  if (typeof optionsOrPlugin !== "function") {
+  }
+  if (!isPlugin(optionsOrPlugin)) {
+    Object.assign((el as HTMLElement).style, defaultStyleReset)
     animation = el.animate(
       [
         {
@@ -590,7 +612,16 @@ function remove(el: Element) {
       { duration: optionsOrPlugin.duration, easing: "ease-out" }
     )
   } else {
-    animation = new Animation(optionsOrPlugin(el, "remove", oldCoords))
+    const [keyframes, options] = getPluginTuple(
+      optionsOrPlugin(el, "remove", oldCoords)
+    )
+    if (options?.styleReset !== false) {
+      Object.assign(
+        (el as HTMLElement).style,
+        options?.styleReset || defaultStyleReset
+      )
+    }
+    animation = new Animation(keyframes)
     animation.play()
   }
   animations.set(el, animation)
@@ -641,6 +672,14 @@ export interface AutoAnimateOptions {
 }
 
 /**
+ * A custom plugin config object
+ */
+export interface AutoAnimationPluginOptions {
+  // provide your own css styles or disable style reset
+  styleReset: CSSStyleDeclaration | false
+}
+
+/**
  * A custom plugin that determines what the effects to run
  */
 export interface AutoAnimationPlugin {
@@ -651,7 +690,7 @@ export interface AutoAnimationPlugin {
       ? Coordinates
       : undefined,
     oldCoordinates?: T extends "remain" ? Coordinates : undefined
-  ): KeyframeEffect
+  ): KeyframeEffect | [KeyframeEffect, AutoAnimationPluginOptions]
 }
 
 /**
@@ -669,7 +708,7 @@ export default function autoAnimate(
     const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
     const isDisabledDueToReduceMotion =
       mediaQuery.matches &&
-      typeof config !== "function" &&
+      !isPlugin(config) &&
       !config.disrespectUserMotionPreference
     if (!isDisabledDueToReduceMotion) {
       enabled.add(el)
@@ -677,7 +716,7 @@ export default function autoAnimate(
         Object.assign(el.style, { position: "relative" })
       }
       forEach(el, updatePos, poll, (element) => resize?.observe(element))
-      if (typeof config === "function") {
+      if (isPlugin(config)) {
         options.set(el, config)
       } else {
         options.set(el, { duration: 250, easing: "ease-in-out", ...config })


### PR DESCRIPTION
Related to [discord discussion](https://discord.com/channels/793529058377072650/976911558573719612/1139047782980784229).

There's my solution for providing a way to configure default style reset which occurs on "remove" action.
It doesn't introduce any breaking change and provides a way to configure more options in the future.

I also added a helper function to determine if passed config is a plugin so the code is more DRY.