### PR TITLE
update solid examples to fix #121

### DIFF
--- a/docs/src/examples/dropdown/dropdown-solid.tsx
+++ b/docs/src/examples/dropdown/dropdown-solid.tsx
@@ -3,19 +3,17 @@ import { createSignal, Show } from "solid-js"
 
 const Dropdown = () => {
   const [show, setShow] = createSignal(false)
-  const reveal = () => setShow(!show)
+  const reveal = () => setShow(!show())
 
-  let parent: HTMLDivElement
-
-  createAutoAnimate(() => parent /* optional config */)
+  const [parent, setEnabled] = createAutoAnimate(/* optional config */)
 
   return (
     <div ref={parent}>
-      <strong className="dropdown-label" onClick={reveal}>
+      <strong class="dropdown-label" onClick={reveal}>
         Click me to open!
       </strong>
       <Show when={show()} keyed>
-        <p className="dropdown-content">Lorum ipsum...</p>
+        <p class="dropdown-content">Lorum ipsum...</p>
       </Show>
     </div>
   )

--- a/docs/src/examples/intro/intro-solid.jsx
+++ b/docs/src/examples/intro/intro-solid.jsx
@@ -1,10 +1,7 @@
 import { createAutoAnimate } from '@formkit/auto-animate/solid'
 
 function MyList () {
-  let animationParent;
-
-  createAutoAnimate(() => animationParent, /* optional config */)
-
+  const [animationParent] = createAutoAnimate()
   return (
     <ul ref={animationParent}>
       {/* 🪄 Magic animations for your list */}

--- a/docs/src/examples/solid/index.ts
+++ b/docs/src/examples/solid/index.ts
@@ -2,11 +2,10 @@ const solidPrimitive = {
   solid: {
     language: "tsx",
     ext: "tsx",
-    example: `import { createSignal, For, Show } from "solid-js"
-import { createAutoAnimate } from "@formkit/auto-animate/solid"
+    example: `import { createSignal, For, Show } from 'solid-js'
+import { createAutoAnimate } from '@formkit/auto-animate/solid'
 
 const App = function () {
-  let parent: HTMLDivElement
   const [parent, setEnabled] = createAutoAnimate(/* optional config */)
 
   const menuItems = ["Home", "Settings", "Logout"]
@@ -41,7 +40,7 @@ const solidDirective = {
   solid: {
     language: "tsx",
     ext: "tsx",
-    example: `import { createSignal } from 'solid-js'
+    example: `import { createSignal, For, Show } from 'solid-js'
 import { createAutoAnimateDirective } from '@formkit/auto-animate/solid'
 
 const App = function () {
@@ -67,7 +66,6 @@ const App = function () {
       </button>
     </div>
   </div>
-</>
 }
 
 export default App`,


### PR DESCRIPTION
The solid examples are using `createAutoAnimate` incorrectly as mentioned in #121 

https://github.com/formkit/auto-animate/commit/f23797a3dd8a7c4ecb5d28ef900965e9d5264e58 partially fixed the docs, but the code still has a few errors.

I removed the leftover duplicate `parent` variables and other various other nits to get the code functional.

Here is a code sandbox with the changed examples in a working solid app.
https://codesandbox.io/p/sandbox/zealous-snyder-f94nyf?file=%2Fsrc%2FApp.tsx%3A2%2C36-2%2C57 