### PR TITLE
docs: update native js example to import from cdn instead of non-existing js folder

### DIFF
--- a/docs/src/examples/intro/intro.html
+++ b/docs/src/examples/intro/intro.html
@@ -3,6 +3,6 @@
 </ul>
 
 <script type="module">
-  import autoAnimate from './js/autoAnimate.js'
+  import autoAnimate from 'https://cdn.jsdelivr.net/npm/@formkit/auto-animate'
   autoAnimate(document.getElementById('myList'))
 </script>


### PR DESCRIPTION
this makes the example directly runnable