### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/nuxt/runtime/plugin.ts
+++ b/src/nuxt/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from "#app"
+import { defineNuxtPlugin } from "#imports"
 import { vAutoAnimate } from "@formkit/auto-animate/vue"
 
 export default defineNuxtPlugin((app) => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.