### PR TITLE
feat(vue): allow useAutoAnimate with Vue component ref

### DIFF
--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -36,8 +36,9 @@ export function useAutoAnimate<T extends Element>(
   }
   onMounted(() => {
     watchEffect(() => {
-      if (element.value instanceof HTMLElement)
-        controller = autoAnimate(element.value, options || {})
+      const el = element.value?.$el || element.value
+      if (el instanceof HTMLElement)
+        controller = autoAnimate(el, options || {})
     })
   })
 


### PR DESCRIPTION
This adds support for using `useAutoAnimate` with a component as the parent.  

When you add `ref="parent"` to a component, the element is found at `parent.value.$el`.  This update checks for component elements or a plain HTML element ref.

Without this change, you have to create a proxy ref to extract the element in the `onMounted` hook, like this:

```vue
<script setup lang="ts">
const [autoAnimateParent, enable] = useAutoAnimate()

// create a "proxy" dragParent ref which will hold a ref to the component.
const dragParent = ref()

// assign the component's $el to the autoAnimateParent once the DOM mounts
onMounted(() => (autoAnimateParent.value = dragParent.value?.$el))
</script>

<template>
  <VueDraggable
    ref="dragParent"
    v-model="items"
    :animation="300"
  >
    <!-- ... -->
  </VueDraggable>
</template>
```

This PR doesn't address the types.  I'm not sure the best way to handle that.  I did pull the code into a local repo to try it out and took this screenshot of the type issue. 

![Screenshot 2023-12-19 at 7 39 52 PM](https://github.com/formkit/auto-animate/assets/128857/92d1979f-fc36-4fda-b4cd-861fa1898bfa)

If you want to instruct me how to proceed on the types, I'll update the code.  Or feel free to edit this PR directly.