### PR TITLE
docs: add bun installation command

### DIFF
--- a/docs/src/examples/installation/index.ts
+++ b/docs/src/examples/installation/index.ts
@@ -14,4 +14,9 @@ export default {
     language: "shell",
     title: "~/my-app",
   },
+  bun: {
+    example: "bun install @formkit/auto-animate",
+    language: "shell",
+    title: "~/my-app",
+  },
 }


### PR DESCRIPTION
There was no Bun command in the installation instructions. It's quite popular right now. I use it myself and like it when the package has a command for it and I can copy-paste the installation command.
I think it will be useful for Bun users!