### PR TITLE
Angular 17.1+ support

### DIFF
--- a/docs/src/examples/angular/index.ts
+++ b/docs/src/examples/angular/index.ts
@@ -2,43 +2,34 @@ const angularDirectiveMain = {
   angular: {
     ext: "angular",
     language: "jsx",
-    example: `import { NgModule } from '@angular/core';
-import { AutoAnimateModule } from '@formkit/auto-animate/angular'
-
-@NgModule({
-  declarations: [AppComponent],
-  imports: [BrowserModule, AutoAnimateModule],
-  bootstrap: [AppComponent],
-})
-export class AppModule {}
-`,
-  },
-}
-
-const angularDirectiveApp = {
-  angular: {
-    ext: "angular",
-    language: "jsx",
     example: `import { Component } from '@angular/core';
+import { AutoAnimateDirective } from '@formkit/auto-animate/angular';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
+  imports: [AutoAnimateDirective],
   template: \`
-    <div *ngFor="let story of stories">
-      <div class="story-card" auto-animate>
-        <h2>{{ story.title }}</h2>
-        <div *ngIf="story.showStory">{{ story.story }}</div>
-        <button (click)="story.showStory = !story.showStory">Toggle story</button>
+    @for (story of stories; track story.title) {
+      <div>
+        <div class="story-card" auto-animate>
+          <h2>{{ story.title }}</h2>
+          @if (story.showStory) {
+            <div>{{ story.story }}</div>
+          }
+          <button (click)="story.showStory = !story.showStory">Toggle story</button>
+        </div>
       </div>
-    </div>
-  \`
+    }
+  \`,
 })
 export class AppComponent {
-  stories = [
+  readonly stories = [
     {title: 'The Ant and The Grasshopper', showStory: false, story: "The ant and the grasshopper were good friends..."},
     {title: 'The Boy Who Cried Wolf', showStory: false, story: "There was once a shepherd boy who liked to play tricks..."},
   ];
-}`,
+}
+`,
   },
 }
-export { angularDirectiveMain, angularDirectiveApp }
+export { angularDirectiveMain }

--- a/docs/src/sections/SectionUsage.vue
+++ b/docs/src/sections/SectionUsage.vue
@@ -256,23 +256,21 @@ import IconQwik from "../components/IconQwik.vue"
 
     <h2 id="usage-angular">Angular directive</h2>
     <p>
-      Angular users can globally register the
-      <code>auto-animate</code> directive. This makes adding transitions and
-      animations as easy as applying an attribute. Import the AutoAnimateModule
-      from <code>@formkit/auto-animate/angular</code> and register it with your
-      Angular app:
+      Import <code>AutoAnimateDirective</code> from
+      <code>@formkit/auto-animate/angular</code> into a module or a standalone
+      component to easily add transitions and animations by applying the
+      <code>auto-animate</code> attribute to the parent element in your template:
     </p>
     <CodeExample :examples="angularDirectiveMain" title="App" />
-    <p>
-      Once you’ve registered the plugin, it can be applied anywhere in your
-      application by adding the <code>auto-animate</code> directive to the
-      parent element:
-    </p>
-    <CodeExample :examples="angularDirectiveApp" title="App" />
     <ActualAngularApp />
     <AsideTip>
       Angular users can pass options by directly setting the options input
       <code>&lt;ul auto-animate [options]="{ duration: 100 }"&gt;</code>
+    </AsideTip>
+    <AsideTip>
+      In Angular versions &lt;16 you can only import <code>AutoAnimateModule</code>
+      in <code>NgModule</code>s. And you have to use auto-animate v0.8.2 or earlier.
+      Angular v16 isn't directly supported, but you can easily write a wrapper.
     </AsideTip>
 
     <!-- <h2 id="usage-qwik">Qwik hook</h2>

--- a/src/angular/index.ts
+++ b/src/angular/index.ts
@@ -1,27 +1,22 @@
 import {
-  AfterViewInit,
   Directive,
   ElementRef,
-  Input,
-  NgModule,
-} from "@angular/core"
+  effect,
+  input,
+} from '@angular/core';
 import autoAnimate, { AutoAnimateOptions } from "../index"
 
+
 @Directive({
-  selector: "[auto-animate]",
+  selector: '[auto-animate]',
+  standalone: true,
 })
-export class AutoAnimateDirective implements AfterViewInit {
-  @Input() options?: Partial<AutoAnimateOptions>
+export class AutoAnimateDirective {
+  readonly options = input<Partial<AutoAnimateOptions>>({});
 
-  constructor(private el: ElementRef) {}
-
-  ngAfterViewInit(): void {
-    autoAnimate(this.el.nativeElement, this.options || {})
+  constructor(el: ElementRef) {
+    effect(() => {
+      autoAnimate(el.nativeElement, this.options());
+    });
   }
 }
-
-@NgModule({
-  declarations: [AutoAnimateDirective],
-  exports: [AutoAnimateDirective],
-})
-export class AutoAnimateModule {}


### PR DESCRIPTION
# Support for newer versions of Angular with signals & standalone component usage.

## Notes

- This prevents new versions of the package from working with older angular versions.
- This also doesn't work with Angular v16, but people can write a 10 line wrapper.

#145
#167