### PR TITLE
more immediate enable/disable of autoanimate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -840,9 +840,11 @@ export default function autoAnimate(
   return Object.freeze({
     parent: el,
     enable: () => {
+      mutations.observe(el, { childList: true })
       enabled.add(el)
     },
     disable: () => {
+      mutations.disconnect()
       enabled.delete(el)
     },
     isEnabled: () => enabled.has(el),


### PR DESCRIPTION
I'm using a drag and drop library and calling `disable()` on drag start does NOT effectively disable autoanimate in time. This seems to work