### PR TITLE
fix: fix link to disable usage section in documentation

### DIFF
--- a/docs/src/sections/SectionUsage.vue
+++ b/docs/src/sections/SectionUsage.vue
@@ -190,7 +190,7 @@ import IconQwik from "../components/IconQwik.vue"
       As an alternative to the <code>v-auto-animate</code> directive, Vue devs
       can use the <code>useAutoAnimate</code> composable. This composable
       supports all the same great features, but also provides a mechanism to
-      <a href="usage-disable">enable and disable</a> animations.
+      <a href="#usage-disable">enable and disable</a> animations.
     </p>
     <p>
       Import the composable from <code>@formkit/auto-animate/vue</code> (the


### PR DESCRIPTION
A simple fix to make the link to Disable usage section work properly in the Vue composable usage section.

<img width="1548" alt="image" src="https://github.com/user-attachments/assets/79c57a7b-4f50-47b6-91dd-0f317573bc2d" />

<img width="1548" alt="image" src="https://github.com/user-attachments/assets/ee4c3382-bdb5-4ede-b9b5-d2a58e12e307" />
