### PR TITLE
fix: prevent duplicate MutationObserver when autoAnimate called twice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -905,9 +905,11 @@ export default function autoAnimate(
           ...(config as Partial<AutoAnimateOptions>),
         })
       }
-      const mo = new MutationObserver(handleMutations)
-      mo.observe(el, { childList: true })
-      mutationObservers.set(el, mo)
+      if (!mutationObservers.has(el)) {
+        const mo = new MutationObserver(handleMutations)
+        mo.observe(el, { childList: true })
+        mutationObservers.set(el, mo)
+      }
       parents.add(el)
     }
   }


### PR DESCRIPTION
## Problem

When `autoAnimate()` is called multiple times on the same element (which happens in React StrictMode as components render twice), a new MutationObserver was being created each time. This caused child-added animations to fail because multiple observers were interfering with each other.

## Solution

Check if a MutationObserver already exists for the element before creating a new one. This ensures idempotent behavior when `autoAnimate()` is called repeatedly on the same element.

## Changes

```diff
-      const mo = new MutationObserver(handleMutations)
-      mo.observe(el, { childList: true })
-      mutationObservers.set(el, mo)
+      if (!mutationObservers.has(el)) {
+        const mo = new MutationObserver(handleMutations)
+        mo.observe(el, { childList: true })
+        mutationObservers.set(el, mo)
+      }
```

This fix was validated by the issue reporter in #232 who confirmed it resolves the problem.

Fixes #232