### PR TITLE
fix: add missing trailing comma in config example

### DIFF
--- a/docs/src/examples/config/index.ts
+++ b/docs/src/examples/config/index.ts
@@ -6,7 +6,7 @@ export default {
   // Animation duration in milliseconds (default: 250)
   duration: 250,
   // Easing for motion (default: 'ease-in-out')
-  easing: 'ease-in-out'
+  easing: 'ease-in-out',
   // When true, this will enable animations even if the user has indicated
   // they don’t want them via prefers-reduced-motion.
   disrespectUserMotionPreference: false


### PR DESCRIPTION
Adds a missing trailing comma after `easing: 'ease-in-out'` in `docs/src/examples/config/index.ts`, fixing a syntax error in the config example