### PR TITLE
style: fix framework jumplinks description visibility

### DIFF
--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -372,7 +372,14 @@ li.formkit-message {
 }
 .framework-jumplinks a span {
   position: absolute;
-  left: -999px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border-width: 0;
 }
 .balls {
   background: url('./img/triangle.svg');


### PR DESCRIPTION
I recently accessed the website and noticed that the frameworks links had a `span` element that was visible in my 4K monitor.

This PR updates the styles to match tailwind's `sr-only` class to hide the element visually without hiding it from screen readers


| Before | After |
| ------- | ------- |
| <img width="1280" alt="Shot 2026-04-02 at 15 55 40" src="https://github.com/user-attachments/assets/04079227-6c5b-45ca-b892-3fa68d3fde16" /> | <img width="1280" alt="Shot 2026-04-02 at 15 57 40" src="https://github.com/user-attachments/assets/b1e3682c-d241-4f43-862f-2fec26dcbd6e" /> |
  