### PR TITLE
fix: wrap nuxt runtime plugin in defineNuxtPlugin

### DIFF
--- a/src/nuxt/runtime/plugin.ts
+++ b/src/nuxt/runtime/plugin.ts
@@ -1,3 +1,4 @@
+import { defineNuxtPlugin } from "#imports"
 import { vAutoAnimate } from "../../vue/index"
 
 type NuxtAppLike = {
@@ -9,7 +10,7 @@ type NuxtAppLike = {
   }
 }
 
-export default function autoAnimateNuxtPlugin(app: NuxtAppLike) {
+export default defineNuxtPlugin((nuxtApp: NuxtAppLike) => {
   // Register the directive
-  app.vueApp.directive("auto-animate", vAutoAnimate)
-}
+  nuxtApp.vueApp.directive("auto-animate", vAutoAnimate)
+})


### PR DESCRIPTION
Fixes #240

Since v0.10.0 Nuxt prints a warning that the plugin is not wrapped in `defineNuxtPlugin` — the wrapper was dropped in eb9285b during the build rework.

Turns out it wasn't actually needed for the build: mkdist doesn't resolve imports, so `#imports` passes through to the published `plugin.mjs` just fine. This restores the wrapper and keeps the relative vue import.

Tested in `build/nuxt-playground` with Nuxt 4.4.8 — warning is gone, directive still registers.